### PR TITLE
Add refund workflow and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# AI Code Bank Sandbox API
+
+A fully asynchronous FastAPI application that emulates a Stripe-style sandbox for integration tests. The service persists data with SQLModel and offers deterministic identifiers, ledger tracking, idempotency support, and background webhook retries. **All endpoints are for test use only and never move real money.**
+
+## Features
+
+- Token, customer, balance, charge, and event endpoints with strict sandbox headers.
+- Persistent ledger that records every transaction event, including refunds.
+- Idempotency key storage to guarantee repeatable responses.
+- Optional webhook delivery with exponential backoff and HMAC signatures.
+- New refund workflow with partial and full refunds plus charge summaries.
+- SQLite-compatible JSON columns, making local testing fast and dependency-free.
+- Automated regression test that exercises the full charge/refund lifecycle.
+
+## Requirements
+
+The application targets Python 3.11. Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the API locally
+
+1. Export environment overrides if needed (optional):
+   ```bash
+   export SANDBOX_API_KEY="your_test_key"
+   export SANDBOX_HMAC_SECRET="super_secret"
+   export DATABASE_URL="sqlite+aiosqlite:///./sandbox.db"
+   ```
+2. Start the server:
+   ```bash
+   uvicorn app.main:app --reload --port 8080
+   ```
+3. Send requests with the required headers:
+   - `X-Test-Mode: 1`
+   - `X-Api-Key: <your SANDBOX_API_KEY>`
+   - `X-Signature: <HMAC signature>` (only when `REQUIRE_HMAC=true`)
+
+## Key endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/v1/tokens` | Create a disposable token. |
+| `POST` | `/v1/customers` | Register a customer and provision a seeded ledger. |
+| `GET` | `/v1/accounts/{account_id}/balance` | Retrieve ledger balance details. |
+| `POST` | `/v1/charges` | Create a charge and reduce the customer's balance. |
+| `GET` | `/v1/customers/{customer_id}/charges` | List recent charges with refund totals. |
+| `POST` | `/v1/charges/{charge_id}/refunds` | Issue partial or full refunds with idempotency support. |
+| `GET` | `/v1/accounts/{account_id}/events` | Inspect chronological ledger events. |
+| `GET` | `/health` | Lightweight liveness probe. |
+
+Each response contains `"test_only": true` to emphasise that no real funds move.
+
+## Testing
+
+Run the asynchronous pytest suite, which provisions an isolated SQLite database and validates the end-to-end payment flow:
+
+```bash
+pytest
+```
+
+The test covers customer creation, charging, partial refunds, full refunds, ledger balance recovery, and audit events.
+
+## Deployment notes
+
+- The included Dockerfile (named `code`) installs dependencies via `requirements.txt` and exposes the app on port `8080`.
+- For PostgreSQL deployments, set `DATABASE_URL` accordingly; JSON columns automatically adapt to portable SQLAlchemy types.
+- Configure webhook endpoints by storing a `webhook_url` value in customer metadata to receive `charge.succeeded` and `charge.refunded` notifications.
+
+## Next steps
+
+- Extend the webhook payloads with signature timestamps for replay protection.
+- Add pagination and filtering to the charge listing endpoint.
+- Introduce API key management endpoints to rotate sandbox credentials programmatically.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn[standard]
+sqlmodel
+asyncpg
+httpx
+pydantic
+aiosqlite
+pytest
+pytest-asyncio
+asgi-lifespan

--- a/tests/test_sandbox_api.py
+++ b/tests/test_sandbox_api.py
@@ -1,0 +1,115 @@
+import asyncio
+import importlib
+import os
+from typing import AsyncIterator, Dict
+
+import httpx
+import pytest
+from asgi_lifespan import LifespanManager
+from sqlmodel import SQLModel
+
+
+@pytest.fixture(scope="module")
+def event_loop() -> AsyncIterator[asyncio.AbstractEventLoop]:
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="module")
+async def sandbox_app(tmp_path_factory) -> AsyncIterator[object]:
+    db_dir = tmp_path_factory.mktemp("db")
+    db_path = db_dir / "sandbox.db"
+    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{db_path}"
+
+    import app.main as main
+
+    main = importlib.reload(main)
+    async with main.async_engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    yield main
+
+
+@pytest.fixture
+async def client(sandbox_app) -> AsyncIterator[httpx.AsyncClient]:
+    async with LifespanManager(sandbox_app.app):
+        async with httpx.AsyncClient(app=sandbox_app.app, base_url="http://test") as test_client:
+            yield test_client
+
+
+@pytest.mark.asyncio
+async def test_charge_and_refund_flow(client: httpx.AsyncClient, sandbox_app) -> None:
+    headers: Dict[str, str] = {
+        "X-Test-Mode": "1",
+        "X-Api-Key": sandbox_app.SANDBOX_API_KEY,
+    }
+
+    customer_payload = {
+        "name": "Test Customer",
+        "email": "customer@example.com",
+        "initial_balance_usd": "1000.00",
+    }
+    create_customer = await client.post("/v1/customers", json=customer_payload, headers=headers)
+    assert create_customer.status_code == 200
+    customer_id = create_customer.json()["id"]
+
+    balance_response = await client.get(f"/v1/accounts/{customer_id}/balance", headers=headers)
+    assert balance_response.status_code == 200
+    assert balance_response.json()["balance"] == "1,000.00 USD"
+
+    charge_payload = {
+        "customer_id": customer_id,
+        "amount_cents": 5000,
+        "currency": "USD",
+        "description": "Integration test charge",
+    }
+    create_charge = await client.post("/v1/charges", json=charge_payload, headers=headers)
+    assert create_charge.status_code == 200
+    charge_data = create_charge.json()
+    assert charge_data["status"] == "succeeded"
+    assert charge_data["amount_cents"] == 5000
+    charge_id = charge_data["id"]
+
+    list_charges = await client.get(f"/v1/customers/{customer_id}/charges", headers=headers)
+    assert list_charges.status_code == 200
+    charges = list_charges.json()
+    assert charges["count"] == 1
+    assert charges["charges"][0]["id"] == charge_id
+
+    refund_payload = {"amount_cents": 2000, "reason": "customer_request"}
+    partial_refund = await client.post(
+        f"/v1/charges/{charge_id}/refunds", json=refund_payload, headers=headers
+    )
+    assert partial_refund.status_code == 200
+    refund_data = partial_refund.json()
+    assert refund_data["amount_cents"] == 2000
+    assert refund_data["reason"] == "customer_request"
+
+    charges_after_partial = await client.get(f"/v1/customers/{customer_id}/charges", headers=headers)
+    assert charges_after_partial.status_code == 200
+    charge_summary = charges_after_partial.json()["charges"][0]
+    assert charge_summary["status"] == "partially_refunded"
+    assert charge_summary["refunded_cents"] == 2000
+
+    final_refund = await client.post(f"/v1/charges/{charge_id}/refunds", headers=headers)
+    assert final_refund.status_code == 200
+    final_refund_data = final_refund.json()
+    assert final_refund_data["amount_cents"] == 3000
+
+    charges_after_full = await client.get(f"/v1/customers/{customer_id}/charges", headers=headers)
+    assert charges_after_full.status_code == 200
+    charge_summary = charges_after_full.json()["charges"][0]
+    assert charge_summary["status"] == "refunded"
+    assert charge_summary["refunded_cents"] == 5000
+
+    balance_after = await client.get(f"/v1/accounts/{customer_id}/balance", headers=headers)
+    assert balance_after.status_code == 200
+    assert balance_after.json()["balance"] == "1,000.00 USD"
+
+    events = await client.get(f"/v1/accounts/{customer_id}/events", headers=headers)
+    assert events.status_code == 200
+    event_types = [event["type"] for event in events.json()["events"]]
+    assert event_types.count("charge") == 1
+    assert event_types.count("refund") == 2


### PR DESCRIPTION
## Summary
- add a refund endpoint and charge listing that expose refund totals and webhook events
- switch JSON columns to portable SQLAlchemy JSON for local sqlite compatibility and add helper utilities
- introduce an async regression test plus README and requirements file for easier onboarding

## Testing
- pytest *(fails: ModuleNotFoundError: httpx because dependencies could not be installed in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e48fafe6a8832782b938f5acc2eeb2