### PR TITLE
Fix async engine reconfiguration when DATABASE_URL changes

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,3 +1,5 @@
+import os
+
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -6,11 +8,34 @@ from app.config import DATABASE_URL
 # ---------------------------------------------------------------------------
 # Database setup (async)
 # ---------------------------------------------------------------------------
-async_engine = create_async_engine(DATABASE_URL, echo=False, future=True)
-AsyncSessionLocal = sessionmaker(
-    async_engine, expire_on_commit=False, class_=AsyncSession
-)
+_current_database_url = DATABASE_URL
+
+
+def _resolve_database_url() -> str:
+    return os.environ.get("DATABASE_URL", DATABASE_URL)
+
+
+async_engine = create_async_engine(_current_database_url, echo=False, future=True)
+AsyncSessionLocal = sessionmaker(async_engine, expire_on_commit=False, class_=AsyncSession)
+
+
+def refresh_engine_if_needed() -> None:
+    global _current_database_url, async_engine, AsyncSessionLocal
+
+    resolved_url = _resolve_database_url()
+    if resolved_url == _current_database_url:
+        return
+
+    _current_database_url = resolved_url
+    async_engine = create_async_engine(_current_database_url, echo=False, future=True)
+    AsyncSessionLocal = sessionmaker(async_engine, expire_on_commit=False, class_=AsyncSession)
+
+
+def get_async_engine():
+    refresh_engine_if_needed()
+    return async_engine
 
 async def get_session() -> AsyncSession:
+    refresh_engine_if_needed()
     async with AsyncSessionLocal() as session:
         yield session  # pragma: no cover - thin wrapper

--- a/app/main.py
+++ b/app/main.py
@@ -18,10 +18,10 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from sqlmodel import SQLModel, select
 
-from app.database import async_engine, AsyncSessionLocal
+from app import database
 from app.models import Customer, Ledger
 from app.utils import make_id, money_to_cents, cents_to_str
-from app.config import DEFAULT_TRILLION_BALANCE_USD
+from app.config import DEFAULT_TRILLION_BALANCE_USD, SANDBOX_API_KEY as CONFIG_SANDBOX_API_KEY
 from app.routers import v1
 
 # ---------------------------------------------------------------------------
@@ -52,6 +52,11 @@ app.add_middleware(
 
 app.include_router(v1.router)
 
+# Keep compatibility for test modules that access main.async_engine directly.
+async_engine = database.get_async_engine()
+# Compatibility export for existing tests and integrations.
+SANDBOX_API_KEY = CONFIG_SANDBOX_API_KEY
+
 
 # ---------------------------------------------------------------------------
 # Startup: create tables and seed demo customer
@@ -59,10 +64,11 @@ app.include_router(v1.router)
 @app.on_event("startup")
 async def on_startup() -> None:
     logger.info("Creating DB tables (if not exist)...")
-    async with async_engine.begin() as conn:
+    async with database.get_async_engine().begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
 
-    async with AsyncSessionLocal() as session:
+    database.refresh_engine_if_needed()
+    async with database.AsyncSessionLocal() as session:
         first = await session.exec(select(Customer))
         first = first.first()
         if not first:


### PR DESCRIPTION
### Motivation
- Tests and runtime setups can override `DATABASE_URL`, but the async engine was created at import time and could remain bound to a stale URL causing failed connections to the default Postgres host.
- Ensure application startup, session creation, and test fixtures always use the currently configured database URL to avoid environment-dependent failures.

### Description
- Added dynamic URL handling in `app/database.py` by tracking `_current_database_url`, adding `_resolve_database_url()`, `refresh_engine_if_needed()`, and `get_async_engine()` and rebuilding the async engine/sessionmaker when the env changes.
- Ensured sessions refresh the engine before use by calling `refresh_engine_if_needed()` in `get_session()`.
- Updated `app/main.py` to use `database.get_async_engine()` for schema creation and `database.AsyncSessionLocal` after calling `database.refresh_engine_if_needed()`, and preserved compatibility exports `async_engine` and `SANDBOX_API_KEY` for existing tests/integrations.

### Testing
- Ran the test suite with `pytest -q`, which completed successfully with `3 passed` and `4 warnings`.
- Verified the fix resolves prior environment-related connection errors during tests (previous runs showed connection failure to the default DB host).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb9e6b3748327a256280842b72edf)