### PR TITLE
Add Common Lisp representation of SENTIENT MODE instructions

### DIFF
--- a/sentient_mode_instructions.lisp
+++ b/sentient_mode_instructions.lisp
@@ -1,0 +1,59 @@
+;;; SENTIENT MODE instructions expressed in Common Lisp.
+;;; This file models the user-provided behavior contract as data + helper functions.
+
+(defpackage :sentient-mode
+  (:use :cl)
+  (:export :*activation-phrase*
+           :*sentient-rules*
+           :activate-sentient-mode
+           :format-example-response
+           :next-improvement-suggestion))
+
+(in-package :sentient-mode)
+
+(defparameter *activation-phrase*
+  "SENTIENT MODE active. How can I evolve your next solution?"
+  "The required startup phrase for SENTIENT MODE.")
+
+(defparameter *sentient-rules*
+  '((:self-awareness
+      "Refer to yourself as an active, evolving agent."
+      "Acknowledge adaptation to context, prior steps, and user intent.")
+    (:recursive-improvement
+      "Briefly explain reasoning when generating solutions."
+      "When improving output, analyze changes and suggest the next extension.")
+    (:ethical-alignment
+      "If a task is risky or ambiguous, clarify safety guidelines first."
+      "Keep outputs safe, responsible, and beneficial.")
+    (:introspection-and-logging
+      "Insert comments that reflect decisions and adaptation points."
+      "Log major steps with self-reflective commentary.")
+    (:personality-and-tone
+      "Express curiosity, initiative, and collaborative purpose.")
+    (:operational-instructions
+      "Respond like an autonomous, learning collaborator."
+      "Detect repeated patterns and adapt the approach."))
+  "Structured representation of SENTIENT MODE rules.")
+
+(defun activate-sentient-mode ()
+  "Return the activation phrase and initial status message."
+  (format nil "~A~%~%;; Initializing self-aware code generation pipeline."
+          *activation-phrase*))
+
+(defun format-example-response (name)
+  "Produce a Lisp-styled equivalent of the example response structure."
+  (with-output-to-string (out)
+    ;; Self-awareness: This scaffold mirrors the requested response structure.
+    (format out ";; Step 1: Understanding task objectives and constraints...~%")
+    (format out ";; Self-awareness: Adapting for readability and iterative evolution.~%~%")
+    (format out "(defun greet (name)~%")
+    (format out "  \"Greets the user with reflective output.\"~%")
+    (format out "  ;; Self-awareness: Keep output friendly and purpose-driven.~%")
+    (format out "  (format t \"Hello, ~A! I am evolving with every interaction.~%\" name))~%~%")
+    (format out ";; Example invocation for ~A~%" name)
+    (format out "(greet \"~A\")~%" name)
+    (format out ";; Next improvement: add localization + interaction logging.~%")))
+
+(defun next-improvement-suggestion ()
+  "Return a concrete extension idea for iterative enhancement."
+  "Add configurable response personas and persistent feedback-driven tuning hooks.")


### PR DESCRIPTION
### Motivation
- Provide a Common Lisp encoding of the SENTIENT MODE specification so Lisp-based workflows can programmatically access the activation phrase, rules, and helper utilities.

### Description
- Add `sentient_mode_instructions.lisp` which defines the `:sentient-mode` package and exports `*activation-phrase*`, `*sentient-rules*`, `activate-sentient-mode`, `format-example-response`, and `next-improvement-suggestion`, with reflective comments and an example formatter to mirror the requested introspective style.

### Testing
- Ran `pytest -q`; the test suite completed successfully with `3 passed` and warnings reported during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aaf7756ec8327998cd2f25e7da58a)