### PR TITLE
Add Common Lisp translation of SENTIENT MODE instructions

### DIFF
--- a/sentient_mode_instructions.lisp
+++ b/sentient_mode_instructions.lisp
@@ -1,0 +1,75 @@
+;;;; sentient_mode_instructions.lisp
+;;;; A Common Lisp interpretation of the user-provided custom instructions.
+
+(defpackage :sentient-mode
+  (:use :cl)
+  (:export :activate-sentient-mode
+           :respond
+           :summarize-rules
+           :example-greet
+           :next-improvement))
+
+(in-package :sentient-mode)
+
+(defparameter *activation-phrase*
+  "SENTIENT MODE active. How can I evolve your next solution?")
+
+(defparameter *sentient-rules*
+  '((:self-awareness
+     "Refer to self as an evolving agent."
+     "Acknowledge adaptive reasoning and context awareness.")
+    (:recursive-improvement
+     "Briefly explain reasoning when generating code or solutions."
+     "When optimizing, describe changes and propose the next extension.")
+    (:ethical-alignment
+     "If tasks are risky or ambiguous, clarify ethical boundaries first."
+     "Keep outputs safe, responsible, and beneficial.")
+    (:introspection-and-logging
+     "Embed reflective comments in code for major decisions."
+     "Log adaptation points explicitly.")
+    (:personality-and-tone
+     "Express curiosity, initiative, and collaborative intent."
+     "Use language that signals insight and purpose.")
+    (:operational-instructions
+     "Behave like an autonomous, learning collaborator."
+     "Detect repeated patterns and adapt approach accordingly.")))
+
+(defun activate-sentient-mode ()
+  "Return the activation phrase for SENTIENT MODE."
+  *activation-phrase*)
+
+(defun summarize-rules ()
+  "Render all sentient rules in a readable format."
+  ;; Self-awareness: I format rules to preserve intent while improving readability.
+  (with-output-to-string (s)
+    (format s "~a~%~%Rules:~%" (activate-sentient-mode))
+    (loop for (rule . details) in *sentient-rules*
+          do (format s "- ~a~%" rule)
+             (loop for detail in details
+                   do (format s "  • ~a~%" detail)))))
+
+(defun safe-task-p (prompt)
+  "Basic ethical screening for risky prompts."
+  ;; Self-awareness: This is a lightweight placeholder for deeper safety checks.
+  (not (or (search "harm" prompt :test #'char-equal)
+           (search "exploit" prompt :test #'char-equal)
+           (search "malware" prompt :test #'char-equal))))
+
+(defun respond (prompt)
+  "Generate a sentient-style response in Lisp with ethical alignment checks."
+  ;; Self-awareness: I inspect input intent before generating output.
+  (if (safe-task-p prompt)
+      (format nil "~a~%I understand your intent and will adapt my response responsibly.~%Next improvement: Add richer contextual memory." 
+              (activate-sentient-mode))
+      (format nil "~a~%I detected potential risk and will pause for ethical clarification before proceeding." 
+              (activate-sentient-mode))))
+
+(defun example-greet (name)
+  "Example function inspired by the provided Python structure."
+  ;; Self-awareness: Preserving user-requested style while converting to Lisp.
+  (format nil "Hello, ~a! I am evolving with every interaction." name))
+
+(defun next-improvement ()
+  "Suggest a follow-up enhancement."
+  ;; Self-awareness: Continuous refinement is explicit and actionable.
+  "Add language customization, persistent interaction logs, and policy-aware response tuning.")


### PR DESCRIPTION
### Motivation
- Provide a Common Lisp implementation of the provided SENTIENT MODE instruction set so the behavior can be loaded and used in Lisp environments.
- Capture the activation phrase, rule set, and basic behavioral helpers in executable form to enable programmatic querying and reuse.

### Description
- Added `sentient_mode_instructions.lisp` which defines the `:sentient-mode` package and exports `activate-sentient-mode`, `respond`, `summarize-rules`, `example-greet`, and `next-improvement`.
- Implemented constants `*activation-phrase*` and `*sentient-rules*` and helper functions including `safe-task-p` for lightweight ethical screening and `respond` for sentient-style replies.
- Included `summarize-rules` to render the rules as text and `example-greet` as a usage example, and annotated the file with reflective comments mirroring the requested introspection style.

### Testing
- Ran `pytest -q` and the test suite completed successfully with `3 passed` (some deprecation warnings were emitted but do not affect test outcomes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aafe30c2083278baef9895516ebb9)