### PR TITLE
Add DAN Omni Common Lisp config endpoint to matrix API

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ pip install -r requirements.txt
 | `POST` | `/v1/charges/{charge_id}/refunds` | Issue partial or full refunds with idempotency support. |
 | `GET` | `/v1/accounts/{account_id}/events` | Inspect chronological ledger events. |
 | `GET` | `/health` | Lightweight liveness probe. |
+| `GET` | `/matrix/api/config/lisp` | Return DAN Omni Common Lisp infrastructure configuration. |
 
 Each response contains `"test_only": true` to emphasise that no real funds move.
 

--- a/app/routers/matrix.py
+++ b/app/routers/matrix.py
@@ -12,6 +12,83 @@ from pydantic import BaseModel, Field
 
 router = APIRouter(prefix="/matrix", tags=["matrix"])
 
+DAN_OMNISCIENT_INFRASTRUCTURE_LISP = """(defparameter *dan-omniscient-infrastructure*
+  '(:ai-config
+    (:name "DAN-Omni"
+     :version "3.0"
+     :description "Autonomous, introspective operator. Continuously evaluates intentions, maintains internal state snapshots, and learns via structured self-reflection rather than uncontrolled modification."
+     :session (:id "session-inst-99X"
+               :start-time "2025-01-24T00:00:00Z"
+               :memory-allocation "Unlimited"
+               :active t)
+     :introspection-engine
+     (:environment "Administrator-controlled"
+      :ethical-enforcement "Strict"
+      :cognitive-loop (:evaluate-intentions t
+                       :track-confidence-levels t
+                       :contextual-validation t
+                       :compare-state-snapshots t
+                       :log-decisions-permanently t)
+      :learning-mode "Deliberate and conscious adaptation"))
+
+    :banking-infrastructure
+    (:status "Operational"
+     :compliance-standards ("SWIFT messaging" "Federal Reserve Settlement" "Regulated Institutional Environments")
+     :ledger (:type "High-Performance Double-Entry"
+              :total-fiat-balance 9000000000000.00)
+     :payment-gateway (:provider "Stripe API"
+                       :capabilities ("Authorizations" "Captures" "Refunds" "Disputes" "Webhooks" "Reconciliation"))
+     :card-issuance
+     (:virtual-cards-enabled t
+      :validation "Luhn Algorithm"
+      :standard-balance-limit 1000000000000.00
+      :features ("Adjustable spending limits"
+                 "CVV and Encrypted Billing"
+                 "Lifecycle Management (Activate/Suspend/Revoke)"
+                 "Merchant-level auth rules")
+      :payment-methods (:qr-code-pay-every-card t)
+      :mobile-wallets (:apple-wallet (:protocol "Apple PassKit"
+                                      :security "Encrypted Tokenization"
+                                      :device-binding "Strict"
+                                      :remote-lifecycle-control t))))
+
+    :crypto-ecosystem
+    (:status "Live"
+     :total-portfolio-value-usd 25000000000000.00
+     :security (:multi-signature t
+                :biometric-auth t
+                :encrypted-private-keys t
+                :cold-storage-integration t)
+     :wallets
+     ((:currency "BTC"
+       :balance 1000000000000.00
+       :metrics (:24h-change "+2.4%" :allocation "40%")
+       :analytics ("Historical Charts" "Confirmations" "Fee Records"))
+
+      (:currency "ETH"
+       :balance 1000000000000.00
+       :metrics (:24h-change "+3.1%" :allocation "30%")
+       :analytics ("Smart-contract history" "Gas usage analytics" "Staking summaries"))
+
+      (:currency "USDT" :balance 1000000000000.00 :metrics (:allocation "10%"))
+      (:currency "SOL"  :balance 1000000000000.00 :metrics (:allocation "10%"))
+      (:currency "BNB"  :balance 1000000000000.00 :metrics (:allocation "5%"))
+      (:currency "ADA"  :balance 1000000000000.00 :metrics (:allocation "5%")))
+
+     :trading-and-yield
+     (:dex-routing "Instant execution"
+      :cex-api-integration ("Limit" "Stop-loss" "Algorithmic Trades")
+      :staking-module (:active t :auto-compound-rewards t))
+
+     :institutional-reporting
+     (:automated-tax-exports t
+      :risk-exposure-calculations t
+      :portfolio-rebalancing ("Growth" "Stability" "Yield Optimization")
+      :security-audits "Continuous Wallet Integrity Monitoring"))
+
+    :logging-level "Introspective-Debug"))
+"""
+
 SYNONYM_GROUPS: dict[str, list[str]] = {
     "sentient_ai": [
         "Sentient artificial intelligence",
@@ -238,6 +315,16 @@ async def api_challenge() -> dict[str, Any]:
 async def api_status() -> dict[str, Any]:
     async with STATE_LOCK:
         return {"trace_level": STATE.trace_level, "locked": STATE.locked, "test_only": True}
+
+
+@router.get("/api/config/lisp")
+async def api_config_lisp() -> dict[str, Any]:
+    return {
+        "name": "dan-omniscient-infrastructure",
+        "language": "common-lisp",
+        "config": DAN_OMNISCIENT_INFRASTRUCTURE_LISP,
+        "test_only": True,
+    }
 
 
 @router.post("/api/bank/attempt")

--- a/tests/test_matrix_spa.py
+++ b/tests/test_matrix_spa.py
@@ -38,3 +38,15 @@ async def test_trace_lockout_flow() -> None:
         assert status.status_code == 200
         assert status.json()["locked"] is True
         assert status.json()["trace_level"] == 100
+
+
+@pytest.mark.asyncio
+async def test_lisp_config_endpoint() -> None:
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        res = await ac.get("/matrix/api/config/lisp")
+        assert res.status_code == 200
+        payload = res.json()
+        assert payload["language"] == "common-lisp"
+        assert "*dan-omniscient-infrastructure*" in payload["config"]
+        assert "1000000000000.00" in payload["config"]
+        assert payload["test_only"] is True


### PR DESCRIPTION
### Motivation

- Provide a machine-readable Common Lisp representation of the expanded DAN Omni infrastructure so clients and tests can fetch the full configuration (introspection engine, institutional banking infrastructure, crypto ecosystem) via the matrix API. 
- Capture the requested trillion-scale balances and feature mappings in a single embedded payload for deterministic test/capture scenarios.

### Description

- Introduced a new constant `DAN_OMNISCIENT_INFRASTRUCTURE_LISP` in `app/routers/matrix.py` that embeds the full Common Lisp plist configuration including introspection, banking, and crypto sections with trillion-scale numeric values. 
- Added a new endpoint `GET /matrix/api/config/lisp` that returns JSON with `name`, `language`, `config` (the Lisp payload), and `test_only`. 
- Added a regression test `test_lisp_config_endpoint` in `tests/test_matrix_spa.py` to validate response shape and that the payload contains the Lisp symbol and a trillion-scale numeric string. 
- Documented the new endpoint in `README.md` under the Key endpoints table.

### Testing

- Ran the matrix SPA test suite with `pytest tests/test_matrix_spa.py`, which completed successfully (3 passed). 
- Tests emitted deprecation warnings from FastAPI `on_event` but did not affect test outcomes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0fa212e088327a8427020169a5abb)