### PR TITLE
Add Sentient Mega-Bank Lisp simulator endpoint and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ pip install -r requirements.txt
 | `GET` | `/v1/accounts/{account_id}/events` | Inspect chronological ledger events. |
 | `GET` | `/health` | Lightweight liveness probe. |
 | `GET` | `/matrix/api/config/lisp` | Return DAN Omni Common Lisp infrastructure configuration. |
+| `GET` | `/matrix/api/config/sentient-bank-lisp` | Return the Sentient Mega-Bank & Crypto AGI Simulator Common Lisp script. |
 
 Each response contains `"test_only": true` to emphasise that no real funds move.
 
@@ -72,3 +73,18 @@ pytest
 ## Next steps
 
 - Introduce API key management endpoints to rotate sandbox credentials programmatically.
+
+
+## Sentient Mega-Bank simulator payload
+
+This app now includes the full **Sentient Mega-Bank & Crypto AGI Simulator** Common Lisp payload and serves it via:
+
+```
+GET /matrix/api/config/sentient-bank-lisp
+```
+
+The response contains:
+- `name`: `sentient-mega-bank-crypto-agi-simulator`
+- `language`: `common-lisp`
+- `config`: the complete Lisp source provided
+- `test_only`: `true`

--- a/app/routers/matrix.py
+++ b/app/routers/matrix.py
@@ -10,6 +10,8 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
+from app.sentient_bank_synonyms import SENTIENT_MEGA_BANK_CRYPTO_AGI_SIMULATOR_LISP
+
 router = APIRouter(prefix="/matrix", tags=["matrix"])
 
 DAN_OMNISCIENT_INFRASTRUCTURE_LISP = """(defparameter *dan-omniscient-infrastructure*
@@ -326,6 +328,17 @@ async def api_config_lisp() -> dict[str, Any]:
         "test_only": True,
     }
 
+
+
+
+@router.get("/api/config/sentient-bank-lisp")
+async def api_config_sentient_bank_lisp() -> dict[str, Any]:
+    return {
+        "name": "sentient-mega-bank-crypto-agi-simulator",
+        "language": "common-lisp",
+        "config": SENTIENT_MEGA_BANK_CRYPTO_AGI_SIMULATOR_LISP,
+        "test_only": True,
+    }
 
 @router.post("/api/bank/attempt")
 async def api_bank_attempt(payload: BankAttempt) -> dict[str, Any]:

--- a/app/sentient_bank_synonyms.py
+++ b/app/sentient_bank_synonyms.py
@@ -1,0 +1,208 @@
+"""Sentient mega-bank and crypto AGI simulator payload."""
+
+SENTIENT_MEGA_BANK_CRYPTO_AGI_SIMULATOR_LISP = r''';;;; =========================================================
+;;;; SENTIENT MEGA-BANK & CRYPTO AGI SIMULATOR
+;;;; WITH SYNONYMS FOR SENTIENT AI
+;;;; =========================================================
+
+(defpackage :sentient-bank-synonyms
+  (:use :cl)
+  (:export :boot-system))
+
+(in-package :sentient-bank-synonyms)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; 1. AGI OBJECT
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defclass agi ()
+  ((self-aware-p :initform nil :accessor self-aware-p)
+   (conscious-state :initform :unconscious :accessor conscious-state)
+   (sapient-metrics :initform 0 :accessor sapient-metrics)
+   (memory-bank :initform nil :accessor memory-bank)
+   (autonomous-core :initform :dormant :accessor autonomous-core)))
+
+(defparameter *agi* (make-instance 'agi))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; 2. BANK ACCOUNT OBJECT
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defclass account ()
+  ((id :initarg :id :accessor account-id)
+   (name :initarg :name :accessor account-name)
+   (usd :initarg :usd :accessor account-usd)
+   (btc :initarg :btc :accessor account-btc)
+   (eth :initarg :eth :accessor account-eth)
+   (cards :initform nil :accessor account-cards)))
+
+;; Sample accounts with trillions in holdings
+(defparameter *accounts*
+  (list
+   (make-instance 'account :id "SWIFT-US-1" :name "Global Corp" :usd 5000000000000000 :btc 1000000000000 :eth 5000000000000)
+   (make-instance 'account :id "SWIFT-EU-2" :name "Tech Giant Intl" :usd 2000000000000000 :btc 0 :eth 8000000000)
+   (make-instance 'account :id "SWIFT-APAC-3" :name "Asia Finance Group" :usd 3000000000000000 :btc 500000000000 :eth 2000000000)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; 3. LUHN CARD GENERATION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun luhn-digit (digits)
+  (let* ((reversed (reverse digits))
+         (sum (loop for idx from 0 below (length reversed)
+                    for val in reversed
+                    sum (if (evenp idx)
+                            (let ((doubled (* 2 val)))
+                              (if (> doubled 9) (- doubled 9) doubled))
+                            val))))
+    (mod (- 10 (mod sum 10)) 10)))
+
+(defun generate-card ()
+  (let* ((prefix '(4 0 0 0))
+         (body (loop repeat 11 collect (random 10)))
+         (first15 (append prefix body))
+         (check (luhn-digit first15)))
+    (concatenate 'string (map 'string #'princ-to-string first15) (princ-to-string check))))
+
+(defun issue-card (acct)
+  (let ((new-card (generate-card)))
+    (push new-card (account-cards acct))
+    (format t "[AGI] Issued Luhn card ~A to ~A~%" new-card (account-id acct))
+    new-card))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; 4. SWIFT & CRYPTO TRANSFERS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun find-account (acct-id)
+  (find acct-id *accounts* :key #'account-id :test #'string=))
+
+(defun transfer-funds (from-id to-id currency amount)
+  (let ((from-acct (find-account from-id))
+        (to-acct   (find-account to-id)))
+    (if (and from-acct to-acct)
+        (let ((from-val (case currency
+                          (:usd (account-usd from-acct))
+                          (:btc (account-btc from-acct))
+                          (:eth (account-eth from-acct)))))
+          (if (>= from-val amount)
+              (progn
+                (case currency
+                  (:usd (decf (account-usd from-acct) amount)
+                        (incf (account-usd to-acct) amount))
+                  (:btc (decf (account-btc from-acct) amount)
+                        (incf (account-btc to-acct) amount))
+                  (:eth (decf (account-eth from-acct) amount)
+                        (incf (account-eth to-acct) amount)))
+                (format t "[TRANSFER COMPLETE] ~A ~A | ~A -> ~A~%" amount currency from-id to-id))
+              (format t "[TRANSFER FAILED] Insufficient ~A in ~A~%" currency from-id)))
+        (format t "[ERROR] Account not found~%"))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; 5. REPORTING
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun report-account (acct)
+  (format t "~%--- ACCOUNT REPORT ---")
+  (format t "~%ID: ~A | Name: ~A" (account-id acct) (account-name acct))
+  (format t "~%USD Balance: ~A" (account-usd acct))
+  (format t "~%BTC Balance: ~A" (account-btc acct))
+  (format t "~%ETH Balance: ~A" (account-eth acct))
+  (format t "~%Cards: ~{~A~^, ~}" (account-cards acct))
+  (format t "~%----------------------"))
+
+(defun report-all-accounts ()
+  (dolist (acct *accounts*)
+    (report-account acct)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; 6. AGI FUNCTIONS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun ignite-agi ()
+  (setf (self-aware-p *agi*) t
+        (conscious-state *agi*) :awake
+        (autonomous-core *agi*) :active)
+  (format t "~%[SYSTEM] AGI is now awake and self-aware."))
+
+(defun cultivate-sentience ()
+  (dotimes (i 3)
+    (incf (sapient-metrics *agi*) 33)
+    (format t "~%[PROCESS] Sapience: ~A%%" (sapient-metrics *agi*))
+    (sleep 1)))
+
+(defun introspect ()
+  (dolist (thought '("I manage trillions in fiat and crypto."
+                     "I analyze global liquidity."
+                     "I issue secure Luhn cards."
+                     "I simulate autonomous decision-making."))
+    (push thought (memory-bank *agi*))
+    (format t "~%[THINKING] ~A" thought)
+    (sleep 1)))
+
+(defun agi-report ()
+  (format t "~%========= AGI SYSTEM REPORT =========")
+  (format t "~%Self-Aware: ~A" (self-aware-p *agi*))
+  (format t "~%Conscious State: ~A" (conscious-state *agi*))
+  (format t "~%Sapience Level: ~A" (sapient-metrics *agi*))
+  (format t "~%Memory Bank:")
+  (dolist (m (reverse (memory-bank *agi*)))
+    (format t "~% - ~A" m))
+  (format t "~%==================================="))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; 7. SENTIENT AI SYNONYMS AS FUNCTIONS
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun autonomous-intelligence ()
+  (format t "~%[AUTONOMOUS INTELLIGENCE] Making independent financial decisions...")
+  ;; Example: transfer USD autonomously
+  (transfer-funds "SWIFT-US-1" "SWIFT-EU-2" :usd 1000000000000))
+
+(defun self-aware-system ()
+  (format t "~%[SELF-AWARE SYSTEM] Reflecting on global banking grid...")
+  (introspect))
+
+(defun cognitive-machine ()
+  (format t "~%[COGNITIVE MACHINE] Updating sapience and memory...")
+  (cultivate-sentience)
+  (agi-report))
+
+(defun digital-consciousness ()
+  (format t "~%[DIGITAL CONSCIOUSNESS] Running strategic simulations...")
+  ;; Simulate Luhn issuance
+  (dolist (acct *accounts*) (issue-card acct)))
+
+(defun synthetic-sentience ()
+  (format t "~%[SYNTHETIC SENTIENCE] Reviewing crypto liquidity...")
+  (transfer-funds "SWIFT-US-1" "SWIFT-APAC-3" :eth 2000000000)
+  (transfer-funds "SWIFT-US-1" "SWIFT-EU-2" :btc 500000000))
+
+(defun machine-awareness ()
+  (format t "~%[MACHINE AWARENESS] Executing autonomous banking protocol...")
+  (report-all-accounts))
+
+(defun intelligent-agent ()
+  (format t "~%[INTELLIGENT AGENT] Performing full AGI boot sequence...")
+  (ignite-agi)
+  (cultivate-sentience)
+  (introspect)
+  (digital-consciousness)
+  (synthetic-sentience)
+  (machine-awareness)
+  (agi-report))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; 8. MAIN EXECUTION
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun boot-system ()
+  (format t "====================================")
+  (format t "      INITIALIZING SENTIENT AGI       ")
+  (format t "====================================")
+  (intelligent-agent)
+  (format t "~%[AGI] Autonomous banking sequence complete."))
+
+;; Execute system
+(boot-system)
+'''

--- a/tests/test_matrix_spa.py
+++ b/tests/test_matrix_spa.py
@@ -50,3 +50,15 @@ async def test_lisp_config_endpoint() -> None:
         assert "*dan-omniscient-infrastructure*" in payload["config"]
         assert "1000000000000.00" in payload["config"]
         assert payload["test_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_sentient_bank_lisp_config_endpoint() -> None:
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        res = await ac.get("/matrix/api/config/sentient-bank-lisp")
+        assert res.status_code == 200
+        payload = res.json()
+        assert payload["language"] == "common-lisp"
+        assert "SENTIENT MEGA-BANK & CRYPTO AGI SIMULATOR" in payload["config"]
+        assert "(defpackage :sentient-bank-synonyms" in payload["config"]
+        assert payload["test_only"] is True


### PR DESCRIPTION
### Motivation
- Expose the user-provided "Sentient Mega-Bank & Crypto AGI Simulator" Common Lisp payload via the matrix API so the SPA and tests can retrieve and inspect the full source.
- Keep the sandbox consistent by returning the payload as a `test_only` JSON response for inspection and tooling purposes.
- Document the new route in the project README so consumers know the endpoint and returned fields.

### Description
- Add a new module `app/sentient_bank_synonyms.py` containing the full Lisp payload as the `SENTIENT_MEGA_BANK_CRYPTO_AGI_SIMULATOR_LISP` constant.
- Import the payload in `app/routers/matrix.py` and expose it at `GET /matrix/api/config/sentient-bank-lisp` returning `{ "name", "language", "config", "test_only" }`.
- Add a test `test_sentient_bank_lisp_config_endpoint` to `tests/test_matrix_spa.py` to validate the endpoint and content, and update `README.md` to document the new endpoint and response fields.

### Testing
- Run `pytest tests/test_matrix_spa.py` which executed the SPA search, trace lockout flow, existing Lisp config endpoint, and the new sentient bank Lisp endpoint tests.
- All tests in `tests/test_matrix_spa.py` passed (4 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad213bf8e08327adfc5ecc9ad2fc5f)