### PR TITLE
Add matrix synonym utility functions and new stats endpoints

### DIFF
--- a/app/routers/matrix.py
+++ b/app/routers/matrix.py
@@ -154,6 +154,25 @@ def _flatten_terms() -> list[tuple[str, str]]:
     return [(group, term) for group, terms in SYNONYM_GROUPS.items() for term in terms]
 
 
+def _normalize_query(value: str) -> str:
+    return value.strip().lower()
+
+
+def _term_match_score(query: str, term: str) -> float:
+    return SequenceMatcher(None, _normalize_query(query), term.lower()).ratio()
+
+
+def _group_summary() -> dict[str, Any]:
+    all_terms = _flatten_terms()
+    term_lengths = [len(term) for _, term in all_terms]
+    return {
+        "group_count": len(SYNONYM_GROUPS),
+        "term_count": len(all_terms),
+        "largest_group": max(SYNONYM_GROUPS.items(), key=lambda row: len(row[1]))[0],
+        "average_term_length": round(sum(term_lengths) / len(term_lengths), 2),
+    }
+
+
 @router.get("", response_class=HTMLResponse)
 async def matrix_home() -> str:
     return """<!DOCTYPE html>
@@ -277,7 +296,7 @@ async def matrix_home() -> str:
 
 @router.get("/api/search")
 async def api_search(q: str) -> list[dict[str, Any]]:
-    q_norm = q.strip().lower()
+    q_norm = _normalize_query(q)
     return [
         {"group": group, "term": term, "score": 1.0}
         for group, term in _flatten_terms()
@@ -289,11 +308,38 @@ async def api_search(q: str) -> list[dict[str, Any]]:
 async def api_fuzzy(q: str, limit: int = 10, min_score: float = 0.3) -> list[dict[str, Any]]:
     rows = []
     for group, term in _flatten_terms():
-        score = SequenceMatcher(None, q.lower().strip(), term.lower()).ratio()
+        score = _term_match_score(q, term)
         if score >= min_score:
             rows.append({"group": group, "term": term, "score": round(score, 2)})
     rows.sort(key=lambda row: row["score"], reverse=True)
     return rows[:limit]
+
+
+
+
+@router.get("/api/groups")
+async def api_groups() -> dict[str, Any]:
+    return {
+        "groups": SYNONYM_GROUPS,
+        "summary": _group_summary(),
+        "test_only": True,
+    }
+
+
+@router.get("/api/term-stats")
+async def api_term_stats(q: str) -> dict[str, Any]:
+    normalized = _normalize_query(q)
+    matches = [
+        {"group": group, "term": term, "score": round(_term_match_score(normalized, term), 2)}
+        for group, term in _flatten_terms()
+    ]
+    matches.sort(key=lambda row: row["score"], reverse=True)
+    return {
+        "query": normalized,
+        "top_match": matches[0] if matches else None,
+        "group_summary": _group_summary(),
+        "test_only": True,
+    }
 
 
 @router.get("/api/scan")

--- a/tests/test_matrix_spa.py
+++ b/tests/test_matrix_spa.py
@@ -62,3 +62,20 @@ async def test_sentient_bank_lisp_config_endpoint() -> None:
         assert "SENTIENT MEGA-BANK & CRYPTO AGI SIMULATOR" in payload["config"]
         assert "(defpackage :sentient-bank-synonyms" in payload["config"]
         assert payload["test_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_groups_and_term_stats_endpoints() -> None:
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        groups = await ac.get("/matrix/api/groups")
+        assert groups.status_code == 200
+        groups_payload = groups.json()
+        assert groups_payload["summary"]["group_count"] >= 1
+        assert "stealth" in groups_payload["groups"]
+
+        stats = await ac.get("/matrix/api/term-stats", params={"q": "covert"})
+        assert stats.status_code == 200
+        stats_payload = stats.json()
+        assert stats_payload["query"] == "covert"
+        assert stats_payload["top_match"]["group"] == "stealth"
+        assert stats_payload["test_only"] is True


### PR DESCRIPTION
### Motivation
- Improve reuse and clarity in the matrix synonym search implementation by extracting normalization, scoring, and summary logic into helpers.
- Provide additional observability and developer-facing metadata for the synonym dataset via new API endpoints.

### Description
- Added helper functions ` _normalize_query`, `_term_match_score`, and `_group_summary` to `app/routers/matrix.py` to centralize query normalization, fuzzy scoring, and group metadata computation.
- Updated `GET /matrix/api/search` and `GET /matrix/api/fuzzy` to use the new helpers for consistent behavior.
- Introduced two new endpoints: `GET /matrix/api/groups` which returns the raw synonym groups and summary, and `GET /matrix/api/term-stats` which returns a normalized query, the top semantic match, and group summary.
- Added regression tests in `tests/test_matrix_spa.py` to cover the new endpoints and assert expected response structure and values.

### Testing
- Ran `pytest -q tests/test_matrix_spa.py tests/test_sanity.py` which completed successfully with all tests passing (`6 passed`).
- New tests assert `GET /matrix/api/groups` returns `summary` and group data and `GET /matrix/api/term-stats?q=covert` returns `query == "covert"` and `top_match` in the `"stealth"` group.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f84054ac4c8327afaaae6269592125)