### PR TITLE
Enhance sandbox API endpoints and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A fully asynchronous FastAPI application that emulates a Stripe-style sandbox fo
 
 ## Features
 
-- Token, customer, balance, charge, and event endpoints with strict sandbox headers.
+- Token, customer, balance, charge, refund, event, and account summary endpoints with strict sandbox headers.
 - Persistent ledger that records every transaction event, including refunds.
 - Idempotency key storage to guarantee repeatable responses.
 - Optional webhook delivery with exponential backoff and HMAC signatures.
 - **Webhook Security**: Webhook signatures now include a timestamp to prevent replay attacks (`X-Signature-Timestamp`).
-- **Pagination**: Charge listing endpoints now support `limit` and `offset` query parameters.
-- New refund workflow with partial and full refunds plus charge summaries.
+- **Pagination**: Charge, refund, and ledger event listings support `limit`, `offset`, totals, and `has_more` metadata.
+- Refund workflow with partial and full refunds, refund listing, charge detail lookup, and account summaries.
 - SQLite-compatible JSON columns, making local testing fast and dependency-free.
 - Automated regression test that exercises the full charge/refund lifecycle.
 
@@ -47,9 +47,12 @@ pip install -r requirements.txt
 | `POST` | `/v1/customers` | Register a customer and provision a seeded ledger. |
 | `GET` | `/v1/accounts/{account_id}/balance` | Retrieve ledger balance details. |
 | `POST` | `/v1/charges` | Create a charge and reduce the customer's balance. |
-| `GET` | `/v1/customers/{customer_id}/charges` | List recent charges with refund totals. Supports `?limit=10&offset=0`. |
+| `GET` | `/v1/customers/{customer_id}/charges` | List charges with refund totals, status filtering, `limit`/`offset`, totals, and `has_more`. |
+| `GET` | `/v1/charges/{charge_id}` | Retrieve a single charge with metadata and refund totals. |
 | `POST` | `/v1/charges/{charge_id}/refunds` | Issue partial or full refunds with idempotency support. |
-| `GET` | `/v1/accounts/{account_id}/events` | Inspect chronological ledger events. |
+| `GET` | `/v1/charges/{charge_id}/refunds` | List refunds for a charge with pagination metadata. |
+| `GET` | `/v1/accounts/{account_id}/summary` | Retrieve charge count, refunded cents, net spend, balance, and event count. |
+| `GET` | `/v1/accounts/{account_id}/events` | Inspect chronological ledger events with optional `event_type`, `limit`, and `offset`. |
 | `GET` | `/health` | Lightweight liveness probe. |
 | `GET` | `/matrix/api/config/lisp` | Return DAN Omni Common Lisp infrastructure configuration. |
 | `GET` | `/matrix/api/config/sentient-bank-lisp` | Return the Sentient Mega-Bank & Crypto AGI Simulator Common Lisp script. |
@@ -73,6 +76,7 @@ pytest
 ## Next steps
 
 - Introduce API key management endpoints to rotate sandbox credentials programmatically.
+- Add a webhook event delivery audit table so tests can inspect retry attempts.
 
 
 ## Sentient Mega-Bank simulator payload

--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,8 @@ PROVIDERS.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Dict
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -32,38 +33,10 @@ logger = logging.getLogger("sandbox")
 
 
 # ---------------------------------------------------------------------------
-# FastAPI application
+# Lifespan: create tables and seed demo customer
 # ---------------------------------------------------------------------------
-app = FastAPI(
-    title="Sandbox Stripe-like API (TEST_ONLY)",
-    version="1.0.0",
-    description=(
-        "Realistic sandbox for testing. ALL RESPONSES ARE TEST_ONLY and NOT REAL "
-        "MONEY."
-    ),
-)
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
-app.include_router(v1.router)
-app.include_router(matrix.router)
-
-# Keep compatibility for test modules that access main.async_engine directly.
-async_engine = database.get_async_engine()
-# Compatibility export for existing tests and integrations.
-SANDBOX_API_KEY = CONFIG_SANDBOX_API_KEY
-
-
-# ---------------------------------------------------------------------------
-# Startup: create tables and seed demo customer
-# ---------------------------------------------------------------------------
-@app.on_event("startup")
-async def on_startup() -> None:
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     logger.info("Creating DB tables (if not exist)...")
     async with database.get_async_engine().begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
@@ -97,7 +70,36 @@ async def on_startup() -> None:
                 demo_id,
                 cents_to_str(balance_cents),
             )
+    yield
 
+
+# ---------------------------------------------------------------------------
+# FastAPI application
+# ---------------------------------------------------------------------------
+app = FastAPI(
+    title="Sandbox Stripe-like API (TEST_ONLY)",
+    version="1.1.0",
+    description=(
+        "Realistic sandbox for testing. ALL RESPONSES ARE TEST_ONLY and NOT REAL "
+        "MONEY."
+    ),
+    lifespan=lifespan,
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(v1.router)
+app.include_router(matrix.router)
+
+# Keep compatibility for test modules that access main.async_engine directly.
+async_engine = database.get_async_engine()
+# Compatibility export for existing tests and integrations.
+SANDBOX_API_KEY = CONFIG_SANDBOX_API_KEY
 
 # ---------------------------------------------------------------------------
 # Health check

--- a/app/routers/v1.py
+++ b/app/routers/v1.py
@@ -1,25 +1,115 @@
 from typing import Any, Dict, List, Optional
-from fastapi import APIRouter, BackgroundTasks, Body, Depends, Header, HTTPException, Request
+
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Body,
+    Depends,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+)
 from fastapi.responses import JSONResponse
-from sqlmodel import select
+from sqlmodel import func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from app.config import DEFAULT_TRILLION_BALANCE_USD
 from app.database import get_session
 from app.dependencies import verify_request_safety
-from app.models import Customer, Ledger, Token, Charge, Refund, IdempotencyKey
+from app.models import Charge, Customer, IdempotencyKey, Ledger, Refund, Token
 from app.schemas import (
-    TokenCreate, TokenResponse,
-    CustomerCreate, CustomerResponse,
-    ChargeCreate, ChargeResponse, ChargesListResponse,
-    RefundCreate, RefundResponse
+    AccountSummaryResponse,
+    ChargeCreate,
+    ChargeResponse,
+    ChargesListResponse,
+    CustomerCreate,
+    CustomerResponse,
+    RefundCreate,
+    RefundResponse,
+    RefundsListResponse,
+    TokenCreate,
+    TokenResponse,
 )
 from app.utils import (
-    make_id, money_to_cents, cents_to_str, total_refunded_cents,
-    deliver_webhook_with_retries
+    cents_to_str,
+    deliver_webhook_with_retries,
+    make_id,
+    money_to_cents,
+    total_refunded_cents,
 )
-from app.config import DEFAULT_TRILLION_BALANCE_USD
 
 router = APIRouter(prefix="/v1")
+
+
+def _idempotency_storage_key(operation: str, key: str) -> str:
+    """Scope idempotency keys per operation to avoid cross-endpoint collisions."""
+    return f"{operation}:{key}"
+
+
+def _model_dump(model: Any) -> Dict[str, Any]:
+    """Return a Pydantic model dictionary across supported Pydantic versions."""
+    if hasattr(model, "model_dump"):
+        return model.model_dump()
+    return model.dict()
+
+
+def _charge_metadata(payload: ChargeCreate) -> Dict[str, Any]:
+    metadata = dict(payload.metadata)
+    if payload.description:
+        metadata["description"] = payload.description
+    if payload.source_token:
+        metadata["source_token"] = payload.source_token
+    return metadata
+
+
+def _refund_metadata(payload: RefundCreate) -> Dict[str, Any]:
+    metadata = dict(payload.metadata)
+    if payload.reason:
+        metadata["reason"] = payload.reason
+    return metadata
+
+
+async def _count_charges(session: AsyncSession, customer_id: str) -> int:
+    result = await session.exec(
+        select(func.count()).select_from(Charge).where(Charge.customer_id == customer_id)
+    )
+    return int(result.one())
+
+
+async def _count_refunds(session: AsyncSession, charge_id: str) -> int:
+    result = await session.exec(
+        select(func.count()).select_from(Refund).where(Refund.charge_id == charge_id)
+    )
+    return int(result.one())
+
+
+async def _charge_response(session: AsyncSession, charge: Charge) -> ChargeResponse:
+    return ChargeResponse(
+        id=charge.id,
+        amount_cents=charge.amount_cents,
+        currency=charge.currency,
+        customer_id=charge.customer_id,
+        status=charge.status,
+        refunded_cents=await total_refunded_cents(session, charge.id),
+        created_at=charge.created_at,
+        metadata=charge.metadata_json or {},
+    )
+
+
+def _refund_response(refund: Refund) -> RefundResponse:
+    metadata = refund.metadata_json or {}
+    return RefundResponse(
+        id=refund.id,
+        charge_id=refund.charge_id,
+        amount_cents=refund.amount_cents,
+        currency=refund.currency,
+        status=refund.status,
+        created_at=refund.created_at,
+        metadata=metadata,
+        reason=metadata.get("reason"),
+    )
+
 
 @router.post("/tokens", response_model=TokenResponse)
 async def create_token(
@@ -58,7 +148,15 @@ async def create_customer(
     await verify_request_safety(request, x_test_mode, x_api_key, x_signature)
 
     customer_id = make_id("cus_test")
-    customer = Customer(id=customer_id, name=payload.name, email=payload.email)
+    metadata = dict(payload.metadata)
+    if payload.webhook_url:
+        metadata["webhook_url"] = payload.webhook_url
+    customer = Customer(
+        id=customer_id,
+        name=payload.name,
+        email=payload.email,
+        metadata_json=metadata,
+    )
     session.add(customer)
 
     usd_amount = (
@@ -87,6 +185,7 @@ async def create_customer(
         id=customer.id,
         name=customer.name,
         email=customer.email,
+        created_at=customer.created_at,
     )
 
 
@@ -115,6 +214,48 @@ async def get_balance(
     }
 
 
+@router.get("/accounts/{account_id}/summary", response_model=AccountSummaryResponse)
+async def account_summary(
+    account_id: str,
+    request: Request,
+    x_test_mode: Optional[str] = Header(None),
+    x_api_key: Optional[str] = Header(None),
+    x_signature: Optional[str] = Header(None),
+    session: AsyncSession = Depends(get_session),
+) -> AccountSummaryResponse:
+    await verify_request_safety(request, x_test_mode, x_api_key, x_signature)
+
+    ledger = await session.get(Ledger, account_id)
+    if not ledger:
+        raise HTTPException(status_code=404, detail="account not found (sandbox)")
+
+    charges_count = await _count_charges(session, account_id)
+    refunded_result = await session.exec(
+        select(func.coalesce(func.sum(Refund.amount_cents), 0))
+        .join(Charge, Refund.charge_id == Charge.id)
+        .where(Charge.customer_id == account_id)
+    )
+    refunded_cents = int(refunded_result.one() or 0)
+    charged_result = await session.exec(
+        select(func.coalesce(func.sum(Charge.amount_cents), 0)).where(
+            Charge.customer_id == account_id
+        )
+    )
+    charged_cents = int(charged_result.one() or 0)
+
+    return AccountSummaryResponse(
+        account_id=ledger.account_id,
+        currency=ledger.currency,
+        balance_cents=str(ledger.balance_cents),
+        balance=cents_to_str(ledger.balance_cents, ledger.currency),
+        charges_count=charges_count,
+        refunded_cents=refunded_cents,
+        net_spend_cents=charged_cents - refunded_cents,
+        event_count=len(ledger.events or []),
+        note="TEST_ONLY analytics summary — no real funds move.",
+    )
+
+
 @router.post("/charges", response_model=ChargeResponse)
 async def create_charge(
     request: Request,
@@ -132,8 +273,13 @@ async def create_charge(
     if not ledger:
         raise HTTPException(status_code=404, detail="customer not found (sandbox)")
 
-    if idempotency_key:
-        stored = await session.get(IdempotencyKey, idempotency_key)
+    storage_key = (
+        _idempotency_storage_key("charge.create", idempotency_key)
+        if idempotency_key
+        else None
+    )
+    if storage_key:
+        stored = await session.get(IdempotencyKey, storage_key)
         if stored:
             return JSONResponse(status_code=200, content=stored.response_payload)
 
@@ -144,8 +290,8 @@ async def create_charge(
         amount_cents=payload.amount_cents,
         currency=payload.currency or "USD",
         status="succeeded",
-        idempotency_key=idempotency_key,
-        metadata_json={"description": payload.description} if payload.description else {},
+        idempotency_key=storage_key,
+        metadata_json=_charge_metadata(payload),
     )
     session.add(charge)
 
@@ -155,31 +301,22 @@ async def create_charge(
             "type": "charge",
             "id": charge_id,
             "amount_cents": -payload.amount_cents,
+            "currency": charge.currency,
             "note": payload.description,
         }
     )
 
-    response_payload: Dict[str, Any] = {
-        "id": charge.id,
-        "object": "charge",
-        "amount_cents": charge.amount_cents,
-        "currency": charge.currency,
-        "customer_id": charge.customer_id,
-        "status": charge.status,
-        "refunded_cents": 0,
-        "test_only": True,
-    }
+    response = await _charge_response(session, charge)
+    response_payload = _model_dump(response)
 
-    if idempotency_key:
-        idempotency = IdempotencyKey(key=idempotency_key, response_payload=response_payload)
+    if storage_key:
+        idempotency = IdempotencyKey(key=storage_key, response_payload=response_payload)
         session.add(idempotency)
 
     await session.commit()
-
-    if idempotency_key:
-        stored = await session.get(IdempotencyKey, idempotency_key)
-        if stored:
-            await session.refresh(charge)
+    await session.refresh(charge)
+    response = await _charge_response(session, charge)
+    response_payload = _model_dump(response)
 
     customer = await session.get(Customer, payload.customer_id)
     webhook_url = (
@@ -195,7 +332,24 @@ async def create_charge(
             secret="webhook_secret_dummy",
         )
 
-    return ChargeResponse(**response_payload)
+    return response
+
+
+@router.get("/charges/{charge_id}", response_model=ChargeResponse)
+async def get_charge(
+    charge_id: str,
+    request: Request,
+    x_test_mode: Optional[str] = Header(None),
+    x_api_key: Optional[str] = Header(None),
+    x_signature: Optional[str] = Header(None),
+    session: AsyncSession = Depends(get_session),
+) -> ChargeResponse:
+    await verify_request_safety(request, x_test_mode, x_api_key, x_signature)
+
+    charge = await session.get(Charge, charge_id)
+    if not charge:
+        raise HTTPException(status_code=404, detail="charge not found (sandbox)")
+    return await _charge_response(session, charge)
 
 
 @router.get("/customers/{customer_id}/charges", response_model=ChargesListResponse)
@@ -205,43 +359,48 @@ async def list_charges(
     x_test_mode: Optional[str] = Header(None),
     x_api_key: Optional[str] = Header(None),
     x_signature: Optional[str] = Header(None),
-    limit: int = 10,
-    offset: int = 0,
+    limit: int = Query(10, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    status: Optional[str] = Query(None),
     session: AsyncSession = Depends(get_session),
 ) -> ChargesListResponse:
     await verify_request_safety(request, x_test_mode, x_api_key, x_signature)
 
-    # Added pagination logic here
+    customer = await session.get(Customer, customer_id)
+    if not customer:
+        raise HTTPException(status_code=404, detail="customer not found (sandbox)")
+
+    base_query = select(Charge).where(Charge.customer_id == customer_id)
+    count_query = (
+        select(func.count()).select_from(Charge).where(Charge.customer_id == customer_id)
+    )
+    if status:
+        base_query = base_query.where(Charge.status == status)
+        count_query = count_query.where(Charge.status == status)
+
+    total_result = await session.exec(count_query)
+    total_count = int(total_result.one())
+
     result = await session.exec(
-        select(Charge)
-        .where(Charge.customer_id == customer_id)
-        .order_by(Charge.created_at.desc())
+        base_query.order_by(Charge.created_at.desc(), Charge.id.desc())
         .offset(offset)
         .limit(limit)
     )
     charges = result.all()
 
-    # To get total count (optional, but good for pagination response)
-    # For now, just returning the count of retrieved items or maybe I should do a separate count query.
-    # The original code returned len(responses), I'll stick to that but for the full list.
-    # Actually, efficient pagination usually requires a separate count query or returning has_more.
-    # But for now, let's just paginate the results.
-
     responses: List[ChargeResponse] = []
     for charge in charges:
-        refunded = await total_refunded_cents(session, charge.id)
-        responses.append(
-            ChargeResponse(
-                id=charge.id,
-                amount_cents=charge.amount_cents,
-                currency=charge.currency,
-                customer_id=charge.customer_id,
-                status=charge.status,
-                refunded_cents=refunded,
-            )
-        )
+        responses.append(await _charge_response(session, charge))
 
-    return ChargesListResponse(customer_id=customer_id, charges=responses, count=len(responses))
+    return ChargesListResponse(
+        customer_id=customer_id,
+        charges=responses,
+        count=len(responses),
+        total_count=total_count,
+        limit=limit,
+        offset=offset,
+        has_more=offset + len(responses) < total_count,
+    )
 
 
 @router.get("/accounts/{account_id}/events")
@@ -251,6 +410,9 @@ async def account_events(
     x_test_mode: Optional[str] = Header(None),
     x_api_key: Optional[str] = Header(None),
     x_signature: Optional[str] = Header(None),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    event_type: Optional[str] = Query(None),
     session: AsyncSession = Depends(get_session),
 ) -> Dict[str, Any]:
     await verify_request_safety(request, x_test_mode, x_api_key, x_signature)
@@ -259,7 +421,21 @@ async def account_events(
     if not ledger:
         raise HTTPException(status_code=404, detail="account not found (sandbox)")
 
-    return {"test_only": True, "account_id": account_id, "events": ledger.events}
+    events = list(ledger.events or [])
+    if event_type:
+        events = [event for event in events if event.get("type") == event_type]
+    total_count = len(events)
+    page = events[offset : offset + limit]
+    return {
+        "test_only": True,
+        "account_id": account_id,
+        "events": page,
+        "count": len(page),
+        "total_count": total_count,
+        "limit": limit,
+        "offset": offset,
+        "has_more": offset + len(page) < total_count,
+    }
 
 
 @router.post("/charges/{charge_id}/refunds", response_model=RefundResponse)
@@ -284,8 +460,13 @@ async def create_refund(
     if not ledger:
         raise HTTPException(status_code=404, detail="customer ledger not found (sandbox)")
 
-    if idempotency_key:
-        stored = await session.get(IdempotencyKey, idempotency_key)
+    storage_key = (
+        _idempotency_storage_key("refund.create", idempotency_key)
+        if idempotency_key
+        else None
+    )
+    if storage_key:
+        stored = await session.get(IdempotencyKey, storage_key)
         if stored:
             return RefundResponse(**stored.response_payload)
 
@@ -295,17 +476,16 @@ async def create_refund(
         raise HTTPException(status_code=400, detail="charge already fully refunded")
 
     refund_amount = payload.amount_cents or remaining
-    if refund_amount <= 0 or refund_amount > remaining:
+    if refund_amount > remaining:
         raise HTTPException(status_code=400, detail="invalid refund amount")
 
     refund_id = make_id("re_test")
-    metadata_payload = {"reason": payload.reason} if payload.reason else {}
     refund = Refund(
         id=refund_id,
         charge_id=charge_id,
         amount_cents=refund_amount,
         currency=charge.currency,
-        metadata_json=metadata_payload,
+        metadata_json=_refund_metadata(payload),
     )
     session.add(refund)
 
@@ -316,6 +496,7 @@ async def create_refund(
             "id": refund_id,
             "charge_id": charge_id,
             "amount_cents": refund_amount,
+            "currency": charge.currency,
             "note": payload.reason,
         }
     )
@@ -326,21 +507,15 @@ async def create_refund(
     elif total_after_refund > 0:
         charge.status = "partially_refunded"
 
-    response_payload = RefundResponse(
-        id=refund.id,
-        charge_id=refund.charge_id,
-        amount_cents=refund.amount_cents,
-        currency=refund.currency,
-        status=refund.status,
-        reason=payload.reason,
-    )
+    response_payload = _model_dump(_refund_response(refund))
 
-    if idempotency_key:
-        idempotency = IdempotencyKey(key=idempotency_key, response_payload=response_payload.dict())
+    if storage_key:
+        idempotency = IdempotencyKey(key=storage_key, response_payload=response_payload)
         session.add(idempotency)
 
     await session.commit()
     await session.refresh(refund)
+    response = _refund_response(refund)
 
     customer = await session.get(Customer, charge.customer_id)
     webhook_url = (
@@ -349,22 +524,54 @@ async def create_refund(
         else None
     )
     if webhook_url:
-        charge_payload = ChargeResponse(
-            id=charge.id,
-            amount_cents=charge.amount_cents,
-            currency=charge.currency,
-            customer_id=charge.customer_id,
-            status=charge.status,
-            refunded_cents=total_after_refund,
-        ).dict()
+        charge_payload = _model_dump(await _charge_response(session, charge))
         background.add_task(
             deliver_webhook_with_retries,
             webhook_url,
             {
                 "type": "charge.refunded",
-                "data": {"refund": response_payload.dict(), "charge": charge_payload},
+                "data": {"refund": _model_dump(response), "charge": charge_payload},
             },
             secret="webhook_secret_dummy",
         )
 
-    return response_payload
+    return response
+
+
+@router.get("/charges/{charge_id}/refunds", response_model=RefundsListResponse)
+async def list_refunds(
+    charge_id: str,
+    request: Request,
+    x_test_mode: Optional[str] = Header(None),
+    x_api_key: Optional[str] = Header(None),
+    x_signature: Optional[str] = Header(None),
+    limit: int = Query(10, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    session: AsyncSession = Depends(get_session),
+) -> RefundsListResponse:
+    await verify_request_safety(request, x_test_mode, x_api_key, x_signature)
+
+    charge = await session.get(Charge, charge_id)
+    if not charge:
+        raise HTTPException(status_code=404, detail="charge not found (sandbox)")
+
+    total_count = await _count_refunds(session, charge_id)
+    result = await session.exec(
+        select(Refund)
+        .where(Refund.charge_id == charge_id)
+        .order_by(Refund.created_at.desc(), Refund.id.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+    refunds = result.all()
+    responses = [_refund_response(refund) for refund in refunds]
+
+    return RefundsListResponse(
+        charge_id=charge_id,
+        refunds=responses,
+        count=len(responses),
+        total_count=total_count,
+        limit=limit,
+        offset=offset,
+        has_more=offset + len(responses) < total_count,
+    )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,12 +1,14 @@
-from typing import List, Optional
 from decimal import Decimal
-from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
 
 class TokenCreate(BaseModel):
     card_number: Optional[str] = None
-    exp_month: Optional[int] = None
-    exp_year: Optional[int] = None
-    cvc: Optional[str] = None
+    exp_month: Optional[int] = Field(default=None, ge=1, le=12)
+    exp_year: Optional[int] = Field(default=None, ge=2000, le=9999)
+    cvc: Optional[str] = Field(default=None, min_length=3, max_length=4)
 
 
 class TokenResponse(BaseModel):
@@ -19,7 +21,9 @@ class TokenResponse(BaseModel):
 class CustomerCreate(BaseModel):
     name: Optional[str] = None
     email: Optional[str] = None
-    initial_balance_usd: Optional[Decimal] = None
+    initial_balance_usd: Optional[Decimal] = Field(default=None, ge=Decimal("0"))
+    webhook_url: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
 class CustomerResponse(BaseModel):
@@ -27,15 +31,25 @@ class CustomerResponse(BaseModel):
     object: str = "customer"
     name: Optional[str]
     email: Optional[str]
+    created_at: Optional[int] = None
     test_only: bool = True
 
 
 class ChargeCreate(BaseModel):
     customer_id: str
-    amount_cents: int
+    amount_cents: int = Field(gt=0)
     currency: Optional[str] = "USD"
-    description: Optional[str] = None
+    description: Optional[str] = Field(default=None, max_length=500)
     source_token: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("currency")
+    @classmethod
+    def normalize_currency(cls, value: Optional[str]) -> str:
+        normalized = (value or "USD").upper()
+        if len(normalized) != 3 or not normalized.isalpha():
+            raise ValueError("currency must be a three-letter ISO-style code")
+        return normalized
 
 
 class ChargeResponse(BaseModel):
@@ -46,6 +60,8 @@ class ChargeResponse(BaseModel):
     customer_id: str
     status: str
     refunded_cents: int = 0
+    created_at: Optional[int] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
     test_only: bool = True
 
 
@@ -53,12 +69,17 @@ class ChargesListResponse(BaseModel):
     customer_id: str
     charges: List[ChargeResponse]
     count: int
+    total_count: int = 0
+    limit: int = 10
+    offset: int = 0
+    has_more: bool = False
     test_only: bool = True
 
 
 class RefundCreate(BaseModel):
-    amount_cents: Optional[int] = None
-    reason: Optional[str] = None
+    amount_cents: Optional[int] = Field(default=None, gt=0)
+    reason: Optional[str] = Field(default=None, max_length=250)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
 class RefundResponse(BaseModel):
@@ -68,5 +89,31 @@ class RefundResponse(BaseModel):
     amount_cents: int
     currency: str
     status: str
+    created_at: Optional[int] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
     test_only: bool = True
     reason: Optional[str] = None
+
+
+class RefundsListResponse(BaseModel):
+    charge_id: str
+    refunds: List[RefundResponse]
+    count: int
+    total_count: int = 0
+    limit: int = 10
+    offset: int = 0
+    has_more: bool = False
+    test_only: bool = True
+
+
+class AccountSummaryResponse(BaseModel):
+    test_only: bool = True
+    account_id: str
+    currency: str
+    balance_cents: str
+    balance: str
+    charges_count: int
+    refunded_cents: int
+    net_spend_cents: int
+    event_count: int
+    note: str

--- a/tests/test_sandbox_api.py
+++ b/tests/test_sandbox_api.py
@@ -113,3 +113,111 @@ async def test_charge_and_refund_flow(client: httpx.AsyncClient, sandbox_app) ->
     event_types = [event["type"] for event in events.json()["events"]]
     assert event_types.count("charge") == 1
     assert event_types.count("refund") == 2
+
+
+@pytest.mark.asyncio
+async def test_charge_metadata_pagination_summary_and_refund_listing(
+    client: httpx.AsyncClient, sandbox_app
+) -> None:
+    headers: Dict[str, str] = {
+        "X-Test-Mode": "1",
+        "X-Api-Key": sandbox_app.SANDBOX_API_KEY,
+    }
+
+    create_customer = await client.post(
+        "/v1/customers",
+        json={"name": "Metadata User", "initial_balance_usd": "100.00"},
+        headers=headers,
+    )
+    assert create_customer.status_code == 200
+    customer_id = create_customer.json()["id"]
+
+    charge_ids = []
+    for index in range(3):
+        create_charge = await client.post(
+            "/v1/charges",
+            json={
+                "customer_id": customer_id,
+                "amount_cents": 1000 + index,
+                "currency": "usd",
+                "description": f"charge {index}",
+                "metadata": {"order_id": f"ord_{index}"},
+            },
+            headers=headers,
+        )
+        assert create_charge.status_code == 200
+        charge_ids.append(create_charge.json()["id"])
+
+    paged = await client.get(
+        f"/v1/customers/{customer_id}/charges",
+        params={"limit": 2, "offset": 0},
+        headers=headers,
+    )
+    assert paged.status_code == 200
+    page_payload = paged.json()
+    assert page_payload["count"] == 2
+    assert page_payload["total_count"] == 3
+    assert page_payload["has_more"] is True
+    assert page_payload["limit"] == 2
+
+    charge_detail = await client.get(f"/v1/charges/{charge_ids[-1]}", headers=headers)
+    assert charge_detail.status_code == 200
+    detail_payload = charge_detail.json()
+    assert detail_payload["currency"] == "USD"
+    assert detail_payload["metadata"]["order_id"] == "ord_2"
+    assert detail_payload["created_at"] is not None
+
+    refund = await client.post(
+        f"/v1/charges/{charge_ids[-1]}/refunds",
+        json={"amount_cents": 400, "reason": "requested", "metadata": {"ticket": "T-1"}},
+        headers=headers,
+    )
+    assert refund.status_code == 200
+    refund_payload = refund.json()
+    assert refund_payload["metadata"]["ticket"] == "T-1"
+    assert refund_payload["reason"] == "requested"
+
+    refunds = await client.get(f"/v1/charges/{charge_ids[-1]}/refunds", headers=headers)
+    assert refunds.status_code == 200
+    refunds_payload = refunds.json()
+    assert refunds_payload["count"] == 1
+    assert refunds_payload["total_count"] == 1
+    assert refunds_payload["refunds"][0]["id"] == refund_payload["id"]
+
+    summary = await client.get(f"/v1/accounts/{customer_id}/summary", headers=headers)
+    assert summary.status_code == 200
+    summary_payload = summary.json()
+    assert summary_payload["charges_count"] == 3
+    assert summary_payload["refunded_cents"] == 400
+    assert summary_payload["net_spend_cents"] == 2603
+
+    filtered_events = await client.get(
+        f"/v1/accounts/{customer_id}/events",
+        params={"event_type": "refund"},
+        headers=headers,
+    )
+    assert filtered_events.status_code == 200
+    assert filtered_events.json()["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_amount_validation_rejects_non_positive_charge(
+    client: httpx.AsyncClient, sandbox_app
+) -> None:
+    headers: Dict[str, str] = {
+        "X-Test-Mode": "1",
+        "X-Api-Key": sandbox_app.SANDBOX_API_KEY,
+    }
+    create_customer = await client.post(
+        "/v1/customers",
+        json={"name": "Validation User", "initial_balance_usd": "10.00"},
+        headers=headers,
+    )
+    assert create_customer.status_code == 200
+
+    invalid_charge = await client.post(
+        "/v1/charges",
+        json={"customer_id": create_customer.json()["id"], "amount_cents": 0},
+        headers=headers,
+    )
+    assert invalid_charge.status_code == 422


### PR DESCRIPTION
### Motivation
- Improve the sandbox API to provide richer, more realistic test primitives (detailed charge/refund metadata, pagination, summaries) so integration tests can exercise more production-like flows.
- Harden request/response validation and idempotency handling to reduce flaky tests and prevent cross-endpoint idempotency collisions.
- Replace deprecated FastAPI startup handlers with a lifespan manager and update docs to reflect new endpoints and capabilities.

### Description
- Added stricter and expanded schemas in `app/schemas.py` including `ChargeCreate`, `ChargeResponse`, `RefundCreate`, `RefundResponse`, `ChargesListResponse`, `RefundsListResponse`, and `AccountSummaryResponse` with validation, metadata fields, created timestamps, `total_count`, `limit`, `offset`, and `has_more` support. 
- Extended `app/routers/v1.py` with scoped idempotency (`_idempotency_storage_key`), metadata-preserving charge creation, `GET /v1/charges/{charge_id}`, status-filtered and paginated `GET /v1/customers/{customer_id}/charges`, `GET /v1/charges/{charge_id}/refunds`, `GET /v1/accounts/{account_id}/summary`, and filtered/paginated `GET /v1/accounts/{account_id}/events`, plus helper mappers for consistent response shapes. 
- Migrated app startup to a FastAPI `lifespan` context manager in `app/main.py`, bumped app version to `1.1.0`, and preserved test compatibility exports (`async_engine`, `SANDBOX_API_KEY`).
- Added new integration/regression tests in `tests/test_sandbox_api.py` covering metadata, pagination, refund listing, account summary metrics, event filtering, and validation failure for non-positive charge amounts, and updated `README.md` to document the new endpoints and features.

### Testing
- Ran the full test suite with `pytest -q` which completed successfully: `10 passed`.
- Compiled code with `python -m compileall app tests` which succeeded without errors.
- End-to-end verification included creating customers, charges, partial/full refunds, listing/pagination assertions, and schema validation checks via the added tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faeb1326d88327aadc59e243ea12d7)